### PR TITLE
feat: limit API calls to 1 upon concurrent requests with refresh_token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.2.0] - 2023-09-13
+- Feature:
+  - use mutex to limit API calls when multiple authProvider() requests are made before 1st call is resolved
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orderingstack/ordering-core",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Ordering Stack client core library",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",

--- a/src/__mocks__/handlers.ts
+++ b/src/__mocks__/handlers.ts
@@ -16,18 +16,30 @@ export const handlers = [
     if (grantType === 'password') {
       const username = params['username'];
       if (username === 'test@test.pl') {
-        return resp(ctx.status(200), ctx.json(goodAuthResponseBody));
+        return resp(
+          ctx.delay(2000),
+          ctx.status(200),
+          ctx.json(goodAuthResponseBody),
+        );
       }
       if (username === 'anonymous') {
-        return resp(ctx.status(200), ctx.json(goodAuthResponseBody));
+        return resp(
+          ctx.delay(2000),
+          ctx.status(200),
+          ctx.json(goodAuthResponseBody),
+        );
       }
     }
     if (grantType === 'refresh_token') {
       const refreshToken = params['refresh_token'];
       if (refreshToken === 'proper_refresh_token') {
-        return resp(ctx.status(200), ctx.json(goodAuthResponseBody));
+        return resp(
+          ctx.delay(2000),
+          ctx.status(200),
+          ctx.json(goodAuthResponseBody),
+        );
       }
     }
-    return resp(ctx.status(403));
+    return resp(ctx.delay(2000), ctx.status(403));
   }),
 ];

--- a/src/utils/mutex.ts
+++ b/src/utils/mutex.ts
@@ -1,0 +1,60 @@
+export class Mutex {
+  private locked = false;
+  private _interval = 0;
+  constructor(interval = 0) {
+    this.locked = false;
+    this._interval = interval;
+  }
+
+  private static _lock(mutex: Mutex) {
+    if (mutex.locked) {
+      // is already locked, can't execute
+      return false;
+    }
+    mutex.locked = true;
+    // was not already locked, can execute
+    return true;
+  }
+
+  private static _unlock(mutex: Mutex) {
+    if (!mutex.locked) {
+      return false;
+    }
+
+    mutex.locked = false;
+    return true;
+  }
+
+  getLock<T>(func: () => Promise<T>): Promise<T> {
+    const self = this;
+    return new Promise(function executor(resolve, reject) {
+      if (!Mutex._lock(self)) {
+        // was already locked, try again at given interval
+        setTimeout(() => {
+          executor(resolve, reject);
+        }, self._interval);
+        return;
+      }
+
+      // try getting promise
+      let prom;
+      try {
+        prom = func();
+      } catch (e) {
+        reject(e);
+        Mutex._unlock(self);
+        return;
+      }
+
+      Promise.resolve(prom)
+        .then((res) => {
+          resolve(res as T);
+          Mutex._unlock(self);
+        })
+        .catch((err) => {
+          reject(err);
+          Mutex._unlock(self);
+        });
+    });
+  }
+}


### PR DESCRIPTION
Zauważyliśmy że przy kilku jedoczesnych requestach po access_token do authProvider'a, do auth-oauth2/oauth/token jest wywoływane dla każdorazowo. 
Ma to miejsce przy otwieraniu aplikacji mobilnej, co zapewne przyczyniło się do nadmiernego obciążenia usługi auth podczas rozsyłania PUSHy do sporej ilości użytkowników.
Proponowana zmiana ogranicza liczbę requestów po access_token z użyciem refresh_token do 1 na raz. Kolejne requesty z kolejki mogą już otrzymać access_token bez uderzania do API.